### PR TITLE
fix: make Tooltip a client component (#274)

### DIFF
--- a/components/Tooltip/Tooltip.tsx
+++ b/components/Tooltip/Tooltip.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import * as RadixTooltip from "@radix-ui/react-tooltip"
 import { cva, VariantProps } from "class-variance-authority"
 import React from "react"


### PR DESCRIPTION
The toolip example use state internally, a more correct example should show that is a client component